### PR TITLE
[Enhancement] passthru URL testing options

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,14 @@ additional directions. Advanced scenario properties/options can be added.
 * `baseline_url` - **REQUIRED**. Full URL to the "production" version of the site/project. This URL is used to create
   the reference set of images in the visual regression tests. It *must* include a trailing slash.
 * `test_url` - **REQUIRED**. Full URL of the pull request environment that will be tested against the baseline. It *must* include a trailing slash.
-*  `report_results` - Optional. Should the action report the results back to the calling workflow (true) or 
+* `report_results` - Optional. Should the action report the results back to the calling workflow (true) or 
 pass/fail directly (false)? _Default is false_.
 * `paths_location` - Optional. Path to the template-paths.js file. _Default is `./.github/tests/vrt/` from the template's repository root_.
+* `baseline_url_response` - _Optional_. The HTTP response status code we expect from the server for the baseline URL. _Defaults to 200_
+* `test_url_response` - _Optional_. The HTTP response status code we expect from the server for the test URL. _Defaults to 200_
+* `baseline_url_insecure` - _Optional_. Should we use the `--insecure` flag with curl when testing the baseline URL? _Defaults to false_
+* `test_url_insecure` - _Optional_. Should we use the `--insecure` flag with curl when testing the test URL? _Defaults to false_
+
 ## Outputs
 * `results` - String of `true`|`false` indicating if the visual regression test passed/failed. 
 ## Example Usage

--- a/action.yaml
+++ b/action.yaml
@@ -18,6 +18,22 @@ inputs:
     description: 'Percentage of different pixels allowed to pass test. NOT CURRENTLY IMPLEMENTED.'
     required: false
     default: "0.1"
+  baseline_url_response:
+    description: 'The HTTP response status code we expect from the server for the baseline URL. Defaults to 200'
+    required: false
+    default: 200
+  test_url_response:
+    description: 'The HTTP response status code we expect from the server for the test URL. Defaults to 200'
+    required: false
+    default: 200
+  baseline_url_insecure:
+    description: 'Should we use the --insecure flag with curl when testing the baseline URL? Defaults to false'
+    required: false
+    default: 'false'
+  test_url_insecure:
+    description: 'Should we use the --insecure flag with curl when testing the test URL? Defaults to false'
+    required: false
+    default: 'false'
 outputs:
   results:
     description: "Reports from VRT"
@@ -41,6 +57,8 @@ runs:
       uses: platformsh/gha-check-url@main
       with:
         test_url: ${{ inputs.baseline_url }}
+        https_response: ${{ inputs.baseline_url_response }}
+        allow_insecure: ${{ inputs.baseline_url_insecure }}
     #
     # Test that the URL for the site to test returns a 200
     # @todo since this is a repeat of the previous step, consider making it an action we can reuse
@@ -49,8 +67,8 @@ runs:
       uses: platformsh/gha-check-url@main
       with:
         test_url: ${{ inputs.test_url }}
-        # sometimes the PR environment hasnt procured its ssl certificate before the tests begin
-        allow_insecure: 'true'
+        https_response: ${{ inputs.test_url_response }}
+        allow_insecure: ${{ inputs.test_url_insecure }}
     #
     # Check that what the calling workflow gave us for report_results is something we can use
     - name: 'Verify return value'


### PR DESCRIPTION
Adds the following inputs:

-  baseline_url_response
-   test_url_response
-   baseline_url_insecure
-   test_url_insecure

These are passed through to the platformsh/gha-check-url action.

Closes #13 