### PR TITLE
Update action.yaml

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -152,7 +152,7 @@ runs:
     - name: 'export reports'
       id: export-reports
       if: ${{ env.vrt_results == 'false' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: vrt-report
         path: |


### PR DESCRIPTION
v3 of [artifacts upload has been deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/). Moves us to v4